### PR TITLE
Add example report and custom script (netbox-community/netbox#4573)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include netbox_animal_sounds/templates *

--- a/netbox_animal_sounds/reports.py
+++ b/netbox_animal_sounds/reports.py
@@ -1,0 +1,16 @@
+from extras.reports import *
+from .models import Animal
+
+name = "Animal-related reports"
+
+class AnimalReport(Report):
+    description = "Validate that every animal has a sound"
+
+    def test_sound(self):
+        for animal in Animal.objects.all():
+            if animal.sound:
+                self.log_success(animal, f"The {animal.name} says {animal.sound}")
+            else:
+                self.log_failure(animal, f"The {animal.name} makes no sound!")
+
+reports = [AnimalReport]

--- a/netbox_animal_sounds/scripts.py
+++ b/netbox_animal_sounds/scripts.py
@@ -1,0 +1,19 @@
+from extras.scripts import *
+from .models import Animal
+
+name = "Animal-related scripts"
+
+class AnimalScript(Script):
+    class Meta:
+        description = "What does the animal say?"
+
+    animal = StringVar()
+
+    def run(self, data, commit):
+        try:
+            animal = Animal.objects.get(name=data['animal'])
+            self.log_success(f'The {animal.name} says "{animal.sound}"!')
+        except Animal.DoesNotExist:
+            self.log_failure(f'No such animal "{data["animal"]}"')
+
+scripts = [AnimalScript]


### PR DESCRIPTION
Counterpart to https://github.com/netbox-community/netbox/pull/4638 - add examples of how a plugin can package custom scripts and reports. This should be backwards-compatible with older versions of NetBox - the plugin should still work, but the scripts and reports will of course not be available in the UI.

Also, we appear to need a `MANIFEST.in` in order to ensure that the `templates` files from the plugin are actually included when the plugin is installed, so I've added that.